### PR TITLE
Testing_feature_loader

### DIFF
--- a/python/proteolizardalgo/feature_loader_dda.py
+++ b/python/proteolizardalgo/feature_loader_dda.py
@@ -170,8 +170,10 @@ class FeatureLoaderDDA():
         summary = DataFrame({"MonoisotopicMz":self.monoisotopic_mz,
                              "Charge":self.charge,
                              "ScanNumber":self.scan_number,
-                             "FrameID":self.frame_id
-                                })
+                             "FrameID":self.frame_id,
+                             "PrecursorID":self.precursor_id,
+                             }, index = [0])
+        summary.set_index("PrecursorID",inplace=True)
         return summary
 
     def _get_scan_boundaries(self,

--- a/python/test/test_feature_loader_dda.py
+++ b/python/test/test_feature_loader_dda.py
@@ -1,0 +1,42 @@
+"""Tests for proteolizardalgo.feature_loader_dda module
+"""
+import pytest
+from proteolizarddata.data import PyTimsDataHandleDDA
+from proteolizardalgo.feature_loader_dda import FeatureLoaderDDA
+
+@pytest.fixture(scope="module")
+def data_path():
+    # ! set data path to bruker experiment (.d folder) here
+    return "/home/tim/Master/MassSpecDaten/M210115_001_Slot1-1_1_850.d"
+
+@pytest.fixture(scope="module",params=[1000,2000])
+def feature_id(id):
+    return id
+
+class TestFeatureLoaderDDA:
+
+    @pytest.fixture(scope="class")
+    def data_handle(self, data_path):
+        return PyTimsDataHandleDDA(data_path)
+
+    @pytest.fixture(scope="class")
+    def feature_loader(self, data_handle,feature_id):
+        return FeatureLoaderDDA(data_handle,feature_id)
+
+    def test_load_hull_data_3d(self):
+        pass
+
+    def test_fetch_precursor(self):
+        pass
+
+    def test_get_precursor_summary(self):
+        pass
+
+    def test_get_scan_boundaries(self):
+        pass
+
+    def test_get_num_peaks(self):
+        pass
+
+    def test_get_monoisotopic_profile(self):
+        pass

--- a/python/test/test_feature_loader_dda.py
+++ b/python/test/test_feature_loader_dda.py
@@ -1,6 +1,7 @@
 """Tests for proteolizardalgo.feature_loader_dda module
 """
 import pytest
+import pandas as pd
 from proteolizarddata.data import PyTimsDataHandleDDA
 from proteolizardalgo.feature_loader_dda import FeatureLoaderDDA
 
@@ -10,8 +11,8 @@ def data_path():
     return "/home/tim/Master/MassSpecDaten/M210115_001_Slot1-1_1_850.d"
 
 @pytest.fixture(scope="module",params=[1000,2000])
-def feature_id(id):
-    return id
+def feature_id(request):
+    return request.param
 
 class TestFeatureLoaderDDA:
 
@@ -23,20 +24,17 @@ class TestFeatureLoaderDDA:
     def feature_loader(self, data_handle,feature_id):
         return FeatureLoaderDDA(data_handle,feature_id)
 
-    def test_load_hull_data_3d(self):
-        pass
+    @pytest.mark.parametrize("ims_model",["gaussian","DBSCAN"])
+    def test_load_hull_data_3d(self,feature_loader,ims_model):
+        hull_data:pd.DataFrame = feature_loader.load_hull_data_3d(ims_model = ims_model)
+        assert("Scan" in hull_data.columns, "Scan not in hull data")
+        assert("Mz" in hull_data.columns,"Mz not in hull data")
+        assert("Intensity" in hull_data.columns, "Intensity not in hull data")
 
-    def test_fetch_precursor(self):
-        pass
-
-    def test_get_precursor_summary(self):
-        pass
-
-    def test_get_scan_boundaries(self):
-        pass
-
-    def test_get_num_peaks(self):
-        pass
-
-    def test_get_monoisotopic_profile(self):
-        pass
+    def test_get_precursor_summary(self, feature_loader):
+        data:pd.DataFrame = feature_loader._get_precursor_summary()
+        assert(data.shape==(1,4),"Precursor summary DataFrame has wrong shape")
+        assert("MonoisotopicMz" in data.columns ,"No monoisotopic mz in precursor summary")
+        assert("Charge" in data.columns ,"No charge in precursor summary")
+        assert("ScanNumber" in data.columns ,"No scan number in precursor summary")
+        assert("FrameID" in data.columns ,"No frame id in precursor summary")


### PR DESCRIPTION
1. Addition of tests for feature_loader_dda.py
   based on local file. For running those tests
   on a different setup be sure to alter the fixture.
   This will be necessary until we have a proper way to share
   testing data.
2. Minor bug fix in feature_loader_dda.py
    * _get_precursor_summary() failed due to missing
      index. Index is now the id of the feature.